### PR TITLE
Update github_actions_role.tf to use existing role instead of creatin…

### DIFF
--- a/terraform/github_actions_role.tf
+++ b/terraform/github_actions_role.tf
@@ -1,35 +1,3 @@
-resource "aws_iam_role" "github_actions_role" {
-  name = "github-actions-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Effect = "Allow"
-        Principal = {
-          Federated = "arn:aws:iam::${var.aws_account_id}:oidc-provider/token.actions.githubusercontent.com"
-        }
-        Condition = {
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-          }
-          StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repository}:*"
-          }
-        }
-      }
-    ]
-  })
-
-  tags = {
-    Name        = "github-actions-role"
-    Environment = "dev"
-    Project     = "quarkus-lambda-build"
-    Terraform   = "true"
-  }
-}
-
 # Policy for GitHub Actions to deploy infrastructure and Lambda
 resource "aws_iam_policy" "github_actions_policy" {
   name        = "github-actions-policy"
@@ -105,6 +73,6 @@ resource "aws_iam_policy" "github_actions_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "github_actions_policy_attachment" {
-  role       = aws_iam_role.github_actions_role.name
+  role       = "github-actions-role"
   policy_arn = aws_iam_policy.github_actions_policy.arn
 }


### PR DESCRIPTION
This pull request removes the `aws_iam_role` resource for the GitHub Actions role and updates the role reference in the policy attachment to use a hardcoded role name instead. These changes simplify the Terraform configuration by eliminating the dynamically created IAM role resource.

### Removal of IAM Role Resource:
* [`terraform/github_actions_role.tf`](diffhunk://#diff-1a42a2fe77c4c45095ff0968e7269d0bd0f5cbc56ccebaea33fdb104a2a98e5bL1-L32): Deleted the `aws_iam_role` resource `github_actions_role`, which defined the role for GitHub Actions, including its assume role policy and tags.

### Update to Policy Attachment:
* [`terraform/github_actions_role.tf`](diffhunk://#diff-1a42a2fe77c4c45095ff0968e7269d0bd0f5cbc56ccebaea33fdb104a2a98e5bL108-R76): Modified the `aws_iam_role_policy_attachment` resource to reference the hardcoded role name `"github-actions-role"` instead of dynamically referencing `aws_iam_role.github_actions_role.name`.…g a new one