### PR TITLE
Update Export Terraform Outputs step using GitHub Actions multiline s…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,12 +72,17 @@ jobs:
       - name: Export Terraform Outputs
         working-directory: ./terraform
         run: |
-          SQS_QUEUE_URL=$(terraform output -raw sqs_queue_url)
-          SQS_QUEUE_ARN=$(terraform output -raw sqs_queue_arn)
-          LAMBDA_ROLE_ARN=$(terraform output -raw lambda_execution_role_arn)
-          echo "SQS_QUEUE_URL=$SQS_QUEUE_URL" >> $GITHUB_ENV
-          echo "SQS_QUEUE_ARN=$SQS_QUEUE_ARN" >> $GITHUB_ENV
-          echo "LAMBDA_ROLE_ARN=$LAMBDA_ROLE_ARN" >> $GITHUB_ENV
+          echo "SQS_QUEUE_URL<<EOF" >> $GITHUB_ENV
+          terraform output -raw sqs_queue_url >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          
+          echo "SQS_QUEUE_ARN<<EOF" >> $GITHUB_ENV
+          terraform output -raw sqs_queue_arn >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          
+          echo "LAMBDA_ROLE_ARN<<EOF" >> $GITHUB_ENV
+          terraform output -raw lambda_execution_role_arn >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
   build-deploy-lambda:
     name: Build and Deploy Lambda


### PR DESCRIPTION
This pull request updates the Terraform output export process in the GitHub Actions workflow to use a multiline format for setting environment variables. This change ensures proper handling of complex or multiline outputs.

### Updates to GitHub Actions workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L75-R85): Modified the `Export Terraform Outputs` step to use a `<<EOF` multiline format for setting `SQS_QUEUE_URL`, `SQS_QUEUE_ARN`, and `LAMBDA_ROLE_ARN` environment variables. This improves compatibility with outputs that may contain special characters or line breaks.…yntax