### PR TITLE
Fix Terraform outputs in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,9 +77,12 @@ jobs:
         id: terraform-outputs
         working-directory: ./terraform
         run: |
-          echo "sqs_queue_url=$(terraform output -raw sqs_queue_url)" >> $GITHUB_OUTPUT
-          echo "sqs_queue_arn=$(terraform output -raw sqs_queue_arn)" >> $GITHUB_OUTPUT
-          echo "lambda_role_arn=$(terraform output -raw lambda_execution_role_arn)" >> $GITHUB_OUTPUT
+          SQS_URL=$(terraform output -raw sqs_queue_url)
+          SQS_ARN=$(terraform output -raw sqs_queue_arn)
+          ROLE_ARN=$(terraform output -raw lambda_execution_role_arn)
+          echo "sqs_queue_url=${SQS_URL}" >> $GITHUB_OUTPUT
+          echo "sqs_queue_arn=${SQS_ARN}" >> $GITHUB_OUTPUT
+          echo "lambda_role_arn=${ROLE_ARN}" >> $GITHUB_OUTPUT
 
   build-deploy-lambda:
     name: Build and Deploy Lambda


### PR DESCRIPTION
This pull request includes a minor improvement to the Terraform output handling in the `.github/workflows/deploy.yml` file. The change introduces intermediate variables for better readability and maintainability.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L80-R85): Updated the Terraform output script to assign values to intermediate variables (`SQS_URL`, `SQS_ARN`, `ROLE_ARN`) before appending them to `$GITHUB_OUTPUT`.