### PR TITLE
Update GitHub Actions artifact actions to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
           cat tf-outputs.json
 
       - name: Upload Terraform outputs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: terraform-outputs
           path: ./terraform/tf-outputs.json
@@ -116,7 +116,7 @@ jobs:
           aws-region: us-east-1
           
       - name: Download Terraform outputs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: terraform-outputs
           


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/deploy.yml` to use the latest versions of the `upload-artifact` and `download-artifact` actions.

Workflow updates:

* Updated `actions/upload-artifact` from version `v3` to `v4` in the "Upload Terraform outputs" step. (`[.github/workflows/deploy.ymlL84-R84](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L84-R84)`)
* Updated `actions/download-artifact` from version `v3` to `v4` in the "Download Terraform outputs" step. (`[.github/workflows/deploy.ymlL119-R119](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L119-R119)`)