### PR TITLE
Add wait step for Lambda function update to complete before updating …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,6 +170,12 @@ jobs:
             --function-name quarkus-lambda-build \
             --zip-file fileb://build/function.zip
 
+      - name: Wait for Lambda update to complete
+        run: |
+          echo "Waiting for Lambda function update to complete..."
+          aws lambda wait function-updated --function-name quarkus-lambda-build
+          echo "Lambda function update completed"
+
       - name: Update Lambda configuration
         run: |
           aws lambda update-function-configuration \


### PR DESCRIPTION
This pull request updates the deployment workflow to ensure the Lambda function update process is completed before proceeding. The most important change involves adding a step to wait for the Lambda function update to finish.

### Deployment Workflow Enhancements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R173-R178): Added a new step, "Wait for Lambda update to complete," which uses the `aws lambda wait function-updated` command to ensure the Lambda function update is fully completed before moving on to subsequent steps.…configuration