### PR TITLE
Refactor Lambda handlers to use common base classes

### DIFF
--- a/src/main/java/com/steverhoton/poc/AbstractLambdaHandler.java
+++ b/src/main/java/com/steverhoton/poc/AbstractLambdaHandler.java
@@ -1,0 +1,49 @@
+package com.steverhoton.poc;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import jakarta.inject.Inject;
+
+/**
+ * Abstract base class for Lambda handlers that process InputObject and return OutputObject.
+ *
+ * <p>This class implements common functionality shared across multiple Lambda handlers, including
+ * dependency injection of the ProcessingService and request ID handling. Concrete implementations
+ * only need to implement the processInput method.
+ *
+ * @see ProcessingService
+ * @see InputObject
+ * @see OutputObject
+ */
+public abstract class AbstractLambdaHandler implements RequestHandler<InputObject, OutputObject> {
+
+  /** The service responsible for processing the input. */
+  @Inject protected ProcessingService service;
+
+  /**
+   * Handles the Lambda function request by delegating to the processInput method and setting the
+   * AWS request ID on the result.
+   *
+   * @param input The input object containing name and greeting
+   * @param context The Lambda execution context
+   * @return An output object with the processing result and request ID
+   */
+  @Override
+  public OutputObject handleRequest(InputObject input, Context context) {
+    OutputObject result = processInput(input);
+    if (context != null) {
+      result.setRequestId(context.getAwsRequestId());
+    }
+    return result;
+  }
+
+  /**
+   * Process the input object and return an output object without the request ID. Implementations
+   * should override this method to provide specific processing logic.
+   *
+   * @param input The input object to process
+   * @return The processed output object
+   */
+  protected abstract OutputObject processInput(InputObject input);
+}

--- a/src/main/java/com/steverhoton/poc/AbstractSqsEventHandler.java
+++ b/src/main/java/com/steverhoton/poc/AbstractSqsEventHandler.java
@@ -1,0 +1,51 @@
+package com.steverhoton.poc;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+
+/**
+ * Abstract base class for Lambda handlers that process SQS events.
+ *
+ * <p>This class implements the common structure for SQS message processing, allowing subclasses to
+ * focus on the specific logic for each message.
+ */
+public abstract class AbstractSqsEventHandler implements RequestHandler<SQSEvent, Void> {
+
+  /**
+   * Handles SQS event messages by processing each record.
+   *
+   * @param event The SQS event containing one or more messages
+   * @param context The Lambda execution context
+   * @return null as these handlers typically don't produce a return value
+   */
+  @Override
+  public Void handleRequest(SQSEvent event, Context context) {
+    logEventReceived(event);
+
+    for (SQSMessage message : event.getRecords()) {
+      processMessage(message, context);
+    }
+
+    return null;
+  }
+
+  /**
+   * Logs information about the received event.
+   *
+   * @param event The SQS event containing messages
+   */
+  protected void logEventReceived(SQSEvent event) {
+    System.out.println("SQS Event received with " + event.getRecords().size() + " records");
+  }
+
+  /**
+   * Process a single SQS message. Subclasses should implement this method to provide specific
+   * message processing logic.
+   *
+   * @param message The SQS message to process
+   * @param context The Lambda execution context
+   */
+  protected abstract void processMessage(SQSMessage message, Context context);
+}

--- a/src/main/java/com/steverhoton/poc/SqsEventProcessor.java
+++ b/src/main/java/com/steverhoton/poc/SqsEventProcessor.java
@@ -1,8 +1,6 @@
 package com.steverhoton.poc;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 
 import jakarta.inject.Named;
@@ -14,45 +12,37 @@ import jakarta.inject.Named;
  * <p>The processor extracts and logs details from each SQS message, including message ID, receipt
  * handle, source information, body content, and any message attributes.
  *
- * <p>This implementation is optimized for Quarkus' fast startup and low memory footprint, making it
- * suitable for serverless environments.
+ * <p>This implementation extends AbstractSqsEventHandler for common SQS processing logic.
  */
 @Named("sqs-processor")
-public class SqsEventProcessor implements RequestHandler<SQSEvent, Void> {
+public class SqsEventProcessor extends AbstractSqsEventHandler {
 
   /**
-   * Handles SQS event messages by processing and logging their contents.
+   * Processes a single SQS message by logging its details.
    *
-   * @param event The SQS event containing one or more messages
+   * @param message The SQS message to process
    * @param context The Lambda execution context
-   * @return null as this handler doesn't produce a meaningful return value
    */
   @Override
-  public Void handleRequest(SQSEvent event, Context context) {
-    System.out.println("SQS Event received with " + event.getRecords().size() + " records");
+  protected void processMessage(SQSMessage message, Context context) {
+    System.out.println("-------- SQS Message --------");
+    System.out.println("Message ID: " + message.getMessageId());
+    System.out.println("Receipt Handle: " + message.getReceiptHandle());
+    System.out.println(
+        "Queue Source: " + message.getEventSource() + " - " + message.getEventSourceArn());
+    System.out.println("Message Body: " + message.getBody());
 
-    for (SQSMessage message : event.getRecords()) {
-      System.out.println("-------- SQS Message --------");
-      System.out.println("Message ID: " + message.getMessageId());
-      System.out.println("Receipt Handle: " + message.getReceiptHandle());
-      System.out.println(
-          "Queue Source: " + message.getEventSource() + " - " + message.getEventSourceArn());
-      System.out.println("Message Body: " + message.getBody());
-
-      // Print message attributes if any
-      if (message.getMessageAttributes() != null && !message.getMessageAttributes().isEmpty()) {
-        System.out.println("Message Attributes:");
-        message
-            .getMessageAttributes()
-            .forEach(
-                (key, attr) -> {
-                  System.out.println("  " + key + ": " + attr);
-                });
-      }
-
-      System.out.println("----------------------------");
+    // Print message attributes if any
+    if (message.getMessageAttributes() != null && !message.getMessageAttributes().isEmpty()) {
+      System.out.println("Message Attributes:");
+      message
+          .getMessageAttributes()
+          .forEach(
+              (key, attr) -> {
+                System.out.println("  " + key + ": " + attr);
+              });
     }
 
-    return null;
+    System.out.println("----------------------------");
   }
 }

--- a/src/main/java/com/steverhoton/poc/TestLambda.java
+++ b/src/main/java/com/steverhoton/poc/TestLambda.java
@@ -1,36 +1,30 @@
 package com.steverhoton.poc;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-
-import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 /**
  * A basic AWS Lambda handler that processes input objects and returns output objects. This handler
  * is the primary entry point for the Quarkus Lambda application.
  *
- * <p>This implementation uses CDI for dependency injection of the processing service.
+ * <p>This implementation extends the AbstractLambdaHandler to leverage common Lambda processing
+ * logic.
  *
+ * @see AbstractLambdaHandler
  * @see ProcessingService
  * @see InputObject
  * @see OutputObject
  */
 @Named("test")
-public class TestLambda implements RequestHandler<InputObject, OutputObject> {
-
-  /** The service responsible for processing the input. */
-  @Inject ProcessingService service;
+public class TestLambda extends AbstractLambdaHandler {
 
   /**
-   * Handles the Lambda function request.
+   * Processes the input object by delegating to the injected service.
    *
    * @param input The input object containing name and greeting
-   * @param context The Lambda execution context
-   * @return An output object with the processing result and request ID
+   * @return An output object with the processing result
    */
   @Override
-  public OutputObject handleRequest(InputObject input, Context context) {
-    return service.process(input).setRequestId(context.getAwsRequestId());
+  protected OutputObject processInput(InputObject input) {
+    return service.process(input);
   }
 }

--- a/src/main/java/com/steverhoton/poc/UnusedLambda.java
+++ b/src/main/java/com/steverhoton/poc/UnusedLambda.java
@@ -1,9 +1,5 @@
 package com.steverhoton.poc;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-
-import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 /**
@@ -16,21 +12,17 @@ import jakarta.inject.Named;
  * @see TestLambda For the primary Lambda implementation
  */
 @Named("unused")
-public class UnusedLambda implements RequestHandler<InputObject, OutputObject> {
-
-  /** The service responsible for processing the input. */
-  @Inject ProcessingService service;
+public class UnusedLambda extends AbstractLambdaHandler {
 
   /**
-   * Handles the Lambda function request by throwing an exception.
+   * Processes the input object by throwing an exception.
    *
    * @param input The input object containing name and greeting
-   * @param context The Lambda execution context
    * @return This method does not return normally as it throws an exception
    * @throws RuntimeException Always thrown to indicate this Lambda is not meant to be used
    */
   @Override
-  public OutputObject handleRequest(InputObject input, Context context) {
+  protected OutputObject processInput(InputObject input) {
     throw new RuntimeException("Should be unused");
   }
 }


### PR DESCRIPTION
This pull request introduces an abstraction layer for AWS Lambda handlers by creating base classes for common functionality and refactoring existing handlers to extend these base classes. The changes aim to reduce code duplication and improve maintainability.

### New Abstraction Layer for Lambda Handlers:

* [`src/main/java/com/steverhoton/poc/AbstractLambdaHandler.java`](diffhunk://#diff-539a4c08a232f16b6648da43c577f007e16c4f53d43961fc70cf8a290d1c99ecR1-R49): Introduced an abstract base class for Lambda handlers (`AbstractLambdaHandler`) that handles common processing logic, such as dependency injection and request ID handling. Subclasses need to implement the `processInput` method for specific logic.
* [`src/main/java/com/steverhoton/poc/AbstractSqsEventHandler.java`](diffhunk://#diff-687a8ed82b4b9d828862401fa7546951ab188905415b7f097cff90a4fa3dec47R1-R51): Added a new abstract base class for SQS event handlers (`AbstractSqsEventHandler`) to encapsulate common SQS processing logic, including logging and message iteration. Subclasses implement the `processMessage` method.

### Refactoring of Existing Handlers:

* [`src/main/java/com/steverhoton/poc/SqsEventProcessor.java`](diffhunk://#diff-6f5d5ea7e74d718cc423facf356538143fc8dc55bb0715359b8703d05978651fL17-R27): Refactored `SqsEventProcessor` to extend `AbstractSqsEventHandler`, removing redundant code and delegating common logic to the base class. The `handleRequest` method was replaced with an implementation of `processMessage`. [[1]](diffhunk://#diff-6f5d5ea7e74d718cc423facf356538143fc8dc55bb0715359b8703d05978651fL17-R27) [[2]](diffhunk://#diff-6f5d5ea7e74d718cc423facf356538143fc8dc55bb0715359b8703d05978651fL55-L57)
* [`src/main/java/com/steverhoton/poc/TestLambda.java`](diffhunk://#diff-c9d5c9bdaa35c174ba910953630ac4ccc55e2a160954e050ce6e266d33e13f92L3-R28): Refactored `TestLambda` to extend `AbstractLambdaHandler`, simplifying the class by overriding the `processInput` method for specific processing logic.
* [`src/main/java/com/steverhoton/poc/UnusedLambda.java`](diffhunk://#diff-c31bad759b1f0c8581afc55cc2b0eff6f818fa5793d1aa67416daeba2db92e56L19-R25): Updated `UnusedLambda` to extend `AbstractLambdaHandler`, overriding `processInput` to throw an exception, as this Lambda is not meant to be used.Added AbstractLambdaHandler and AbstractSqsEventHandler as base classes to reduce duplicated code. Updated existing handlers to extend these base classes and leverage the common functionality. Implemented template method pattern for improved extension and maintainability.