### PR TITLE
Align project with Java/Quarkus and Terraform standards

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'io.quarkus'
-    id 'com.diffplug.spotless' version '6.25.0'
+    alias(libs.plugins.quarkus)
+    alias(libs.plugins.spotless)
 }
 
 repositories {
@@ -10,20 +10,20 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    implementation 'io.quarkus:quarkus-amazon-lambda'
-    implementation 'com.amazonaws:aws-lambda-java-events:3.11.3'
+    implementation platform(libs.quarkus.bom)
+    implementation libs.quarkus.amazon.lambda
+    implementation libs.awslambda.events
     
     // Add netty resolver for MacOS
-    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-aarch_64'
+    implementation "${libs.netty.resolver.macos.get().module}:osx-aarch_64"
 
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.rest-assured:rest-assured'
-    testImplementation 'org.mockito:mockito-core:5.8.0'
+    testImplementation libs.quarkus.junit5
+    testImplementation libs.rest.assured
+    testImplementation libs.mockito.core
 }
 
-group 'com.steverhoton.poc'
-version '1.0.0-SNAPSHOT'
+group = 'com.steverhoton.poc'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.compilerArgs << '-parameters'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+quarkus = "3.9.0"
+awslambda-events = "3.11.3"
+netty-resolver = "4.1.107.Final"
+mockito = "5.8.0"
+
+[libraries]
+quarkus-bom = { module = "io.quarkus:quarkus-bom", version.ref = "quarkus" }
+quarkus-amazon-lambda = { module = "io.quarkus:quarkus-amazon-lambda" }
+awslambda-events = { module = "com.amazonaws:aws-lambda-java-events", version.ref = "awslambda-events" }
+netty-resolver-macos = { module = "io.netty:netty-resolver-dns-native-macos", version.ref = "netty-resolver" }
+quarkus-junit5 = { module = "io.quarkus:quarkus-junit5" }
+rest-assured = { module = "io.rest-assured:rest-assured" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+
+[plugins]
+quarkus = { id = "io.quarkus", version.ref = "quarkus" }
+spotless = { id = "com.diffplug.spotless", version = "6.25.0" }

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,0 +1,52 @@
+config {
+  module = true
+  force = false
+  disabled_by_default = false
+
+  # AWS plugin settings
+  plugin "aws" {
+    enabled = true
+    version = "0.30.0"
+    source = "github.com/terraform-linters/tflint-ruleset-aws"
+  }
+}
+
+# Basic linting rules
+rule "terraform_deprecated_interpolation" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_required_version" {
+  enabled = true
+}
+
+rule "terraform_required_providers" {
+  enabled = true
+}
+
+rule "terraform_unused_required_providers" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+  format = "snake_case"
+}
+
+# AWS related rules
+rule "aws_resource_missing_tags" {
+  enabled = true
+  tags = ["Environment", "Project", "Terraform"]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,6 +3,15 @@ provider "aws" {
 }
 
 terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+
   backend "s3" {
     bucket = "srhoton-tfstate"
     key    = "quarkus-lambda-build/terraform.tfstate"


### PR DESCRIPTION
This pull request introduces updates to dependency management, Terraform linting configuration, and Terraform provider requirements. The key changes focus on adding versioned dependencies for the project, enhancing Terraform linting rules for better code quality, and specifying required Terraform and AWS provider versions.

### Dependency Management Updates:
* Added new library and plugin versions in `gradle/libs.versions.toml`, including `quarkus`, `awslambda-events`, `netty-resolver`, and `mockito`. These updates centralize dependency versioning and improve maintainability.

### Terraform Configuration Enhancements:
* Introduced a `.tflint.hcl` configuration file to enable Terraform linting with rules for deprecated interpolation, documented outputs/variables, typed variables, required providers, and naming conventions. AWS-specific rules for resource tagging were also added.
* Updated `terraform/main.tf` to specify `required_version` for Terraform (>= 1.5.0) and `required_providers` for AWS (>= 5.0.0), ensuring compatibility and alignment with the latest features.- Fix deprecated Gradle property assignment syntax
- Implement version catalog for dependency management
- Add TFLint configuration for Terraform
- Add Terraform version constraints